### PR TITLE
fix: fixed custom domain footer

### DIFF
--- a/public/css/tailwind.css
+++ b/public/css/tailwind.css
@@ -629,6 +629,9 @@
   .gap-x-3 {
     column-gap: calc(var(--spacing) * 3);
   }
+  .gap-x-4 {
+    column-gap: calc(var(--spacing) * 4);
+  }
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
   }
@@ -863,6 +866,9 @@
   }
   .py-5 {
     padding-block: calc(var(--spacing) * 5);
+  }
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
   }
   .py-8 {
     padding-block: calc(var(--spacing) * 8);

--- a/views/layouts/default.ejs
+++ b/views/layouts/default.ejs
@@ -2,7 +2,8 @@
 <html lang="en">
   <%- include('head') %>
   <body class="bg-gray-100 text-gray-900">
-    <%- include('../partials/navbar') %> <%- body %> <%-
-    include('../partials/footer') %>
+    <%- include('../partials/navbar') %> <%- body %> <% if (mode === 'custom') {
+    %> <%- include('../partials/footer-custom') %> <% } else { %> <%-
+    include('../partials/footer') %> <% } %>
   </body>
 </html>

--- a/views/partials/footer-custom.ejs
+++ b/views/partials/footer-custom.ejs
@@ -1,0 +1,39 @@
+<footer class="border-t border-gray-200 bg-white text-gray-500 text-sm mt-8">
+  <div
+    class="max-w-4xl mx-auto px-4 py-6 flex flex-col sm:flex-row items-center justify-between gap-3"
+  >
+    <span>
+      Powered by
+      <a
+        href="https://rawfeed.social/about"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-700 font-medium hover:underline"
+        >Rawfeed</a
+      >
+    </span>
+    <nav class="flex flex-wrap gap-x-4 gap-y-1 justify-center">
+      <a
+        href="https://rawfeed.social/legal/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:underline"
+        >Privacy Policy</a
+      >
+      <a
+        href="https://rawfeed.social/legal/terms"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:underline"
+        >Terms of Service</a
+      >
+      <a
+        href="https://rawfeed.social/legal/cookies"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:underline"
+        >Cookie Policy</a
+      >
+    </nav>
+  </div>
+</footer>


### PR DESCRIPTION
Profile pages served under custom domains should have a dedicated footer. The footer will be minimal in design and include links to legal pages such as Terms of Service and Privacy Policy.

https://github.com/ozziest/rawfeed.social/issues/22