### PR TITLE
fix: fixed custom domain sitemap bug

### DIFF
--- a/src/helpers/sitemapGenerator.ts
+++ b/src/helpers/sitemapGenerator.ts
@@ -185,6 +185,22 @@ export async function generateHashtagsSitemap(): Promise<string> {
 }
 
 /**
+ * Generates a minimal sitemap for a custom domain profile
+ */
+export function generateCustomDomainSitemap(domainUrl: string): string {
+  const now = new Date().toISOString();
+  const urls: SitemapUrl[] = [
+    {
+      loc: domainUrl,
+      changefreq: "daily",
+      priority: 1.0,
+      lastmod: now,
+    },
+  ];
+  return generateSitemapXml(urls);
+}
+
+/**
  * Generates sitemap index pointing to all sub-sitemaps
  */
 export async function generateSitemapIndex(): Promise<string> {

--- a/src/routes/sitemap.ts
+++ b/src/routes/sitemap.ts
@@ -5,6 +5,7 @@ import {
   generateStaticSitemap,
   generateUsersSitemap,
   generateHashtagsSitemap,
+  generateCustomDomainSitemap,
 } from "../helpers/sitemapGenerator";
 
 /**
@@ -43,30 +44,49 @@ export default async function sitemapRoutes(fastify: FastifyInstance) {
   fastify.get(
     "/sitemap.xml",
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (request.mode === "custom") {
+        const protocol = request.protocol;
+        const hostname = request.hostname;
+        const domainUrl = `${protocol}://${hostname}`;
+        const cacheKey = `sitemap:custom:${hostname}`;
+        await serveSitemap(reply, cacheKey, async () =>
+          generateCustomDomainSitemap(domainUrl),
+        );
+        return;
+      }
       await serveSitemap(reply, "sitemap:index", generateSitemapIndex);
     },
   );
 
-  // Static pages sitemap
+  // Static pages sitemap — not available on custom domains
   fastify.get(
     "/sitemap-static.xml",
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (request.mode === "custom") {
+        return reply.status(404).send({ error: "Not found" });
+      }
       await serveSitemap(reply, "sitemap:static", generateStaticSitemap);
     },
   );
 
-  // Users sitemap
+  // Users sitemap — not available on custom domains
   fastify.get(
     "/sitemap-users.xml",
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (request.mode === "custom") {
+        return reply.status(404).send({ error: "Not found" });
+      }
       await serveSitemap(reply, "sitemap:users", generateUsersSitemap);
     },
   );
 
-  // Hashtags sitemap
+  // Hashtags sitemap — not available on custom domains
   fastify.get(
     "/sitemap-hashtags.xml",
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (request.mode === "custom") {
+        return reply.status(404).send({ error: "Not found" });
+      }
       await serveSitemap(reply, "sitemap:hashtags", generateHashtagsSitemap);
     },
   );


### PR DESCRIPTION
Profile pages served under custom domains currently expose the platform's own sitemap.xml, which was incorrect. Each custom domain should serve its own minimal sitemap scoped to that profile.

https://github.com/ozziest/rawfeed.social/issues/23